### PR TITLE
Fix 404 error for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_branch: gh-pages

--- a/client_quote/index.html
+++ b/client_quote/index.html
@@ -5,9 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
-    <script type="module" crossorigin src="/assets/index-vDH0ROic.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/pdfjs-DNcC3J45.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DUA9mm4F.css">
+    <script type="module" crossorigin src="./assets/index-vDH0ROic.js"></script>
+    <link rel="modulepreload" crossorigin href="./assets/pdfjs-DNcC3J45.js">
+    <link rel="stylesheet" crossorigin href="./assets/index-DUA9mm4F.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Update `index.html` to use relative paths for assets to avoid 404 errors on GitHub Pages.

* Change the `script` tag to use a relative path for `index-vDH0ROic.js`.
* Change the `link` tag to use a relative path for `pdfjs-DNcC3J45.js`.
* Change the `link` tag to use a relative path for `index-DUA9mm4F.css`.

